### PR TITLE
fix typo in header guard

### DIFF
--- a/tntk.h
+++ b/tntk.h
@@ -1,4 +1,4 @@
-#ifndef __TTNKT_H
+#ifndef __TTNTK_H
 #define __TTNTK_H
 
 // POSIX


### PR DESCRIPTION
Typo prevents tntk.h header guard from working as intended